### PR TITLE
Eliminar limitacion de caracteres en el campo lastName

### DIFF
--- a/backend/src/modules/people/entity/people.entity.ts
+++ b/backend/src/modules/people/entity/people.entity.ts
@@ -10,7 +10,7 @@ export class PeopleEntity{
     name:string;
     @Column({type:'varchar', nullable:true})
     municipio:string | null;
-    @Column({type:'varchar', length:50, nullable:true})
+    @Column({type:'varchar', nullable:true})
     lastName:string | null;
     @Column({type:'date', nullable:false})
     birdthDate:Date;


### PR DESCRIPTION
## **Descripción**

Se elimino la limitación de caracteres en el campo lastName de la entidad people, ya que estaba dando problemas a la hora del registro de organizaciones.

### Fixes #139 